### PR TITLE
Update im.php

### DIFF
--- a/drivers/im.php
+++ b/drivers/im.php
@@ -29,12 +29,11 @@ thumb::$drivers['im'] = function($thumb) {
 
     // crop original image with thumb ratio and resize it to thumb dimensions
     $command[] = '-crop ' . $focusCropValues['width'] . 'x' . $focusCropValues['height'] . '+' . $focusCropValues['x1'] . '+' . $focusCropValues['y1'];
-    $command[] =  '^';
-    $command[] = '-resize ' . $thumb->options['width'] . 'x' . $thumb->options['height'];
+    $command[] = '-resize "' . $thumb->options['width'] . 'x' . $thumb->options['height'] . '^"';
   }
   else if ($thumb->options['crop']) {
     $command[] = '-resize';
-    $command[] = $thumb->options['width'] . 'x' . $thumb->options['height'] . '^';
+    $command[] = '"' . $thumb->options['width'] . 'x' . $thumb->options['height'] . '^"';
     $command[] = '-gravity Center -crop ' . $thumb->options['width'] . 'x' . $thumb->options['height'] . '+0+0';
   } 
   else {


### PR DESCRIPTION
1. The ^ operator has to be placed after the width and height.
2. Without quotes it didn't work on one of my client's servers with ImageMagick 6.9.4-9 Q16 i386 2016-06-21 installed. On my Mac I have never had any problems. (ImageMagick 6.9.3-7 Q16 x86_64 2016-03-27)

The adjustments are based on what I found in the documentation under "Basic adjustments to width and height; the operators %, ^, and !":
http://www.imagemagick.org/script/command-line-processing.php#geometry