### PR TITLE
Assign correct number format for default values

### DIFF
--- a/core/focus.php
+++ b/core/focus.php
@@ -86,8 +86,8 @@ class Focus {
    */
   public static function coordinates($file, $axis = null) {  
     $focusCoordinates = array(
-      'x' => 0.5,
-      'y' => 0.5,
+      'x' => focus::numberFormat(0.5),
+      'y' => focus::numberFormat(0.5),
     );
     
     $focusFieldKey = c::get('focus.field.key', 'focus');


### PR DESCRIPTION
If no focus point is assigned to an image, `focusX()` and `focusY()` returns the default value of `0.5`. But in certain non-english languages, this default value is converted to `0,5` instead (a comma instead of a dot).

This PR makes sure that the correct number format is returned, regardless of current language.