### PR TITLE
Make sure the image is alway fully visible + revert button compatibility

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,15 +1,40 @@
 .kirby-focus-field .focus-box {
   position: relative;
-  cursor: crosshair;
   line-height: 0;
   overflow: hidden;
-  background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyFpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNS1jMDE0IDc5LjE1MTQ4MSwgMjAxMy8wMy8xMy0xMjowOToxNSAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENDIE1hY2ludG9zaCIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDpCOTdEOEI3OUE3MDMxMUUzOEIxNEZERTM0N0EzRjlGMSIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDpCOTdEOEI3QUE3MDMxMUUzOEIxNEZERTM0N0EzRjlGMSI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOkI5N0Q4Qjc3QTcwMzExRTM4QjE0RkRFMzQ3QTNGOUYxIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOkI5N0Q4Qjc4QTcwMzExRTM4QjE0RkRFMzQ3QTNGOUYxIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+jGcG/wAAAAlQTFRF////zMzMzc3NCvMx6wAAACJJREFUeNpiYGRkYgQBBhgYIAGEBCO6SpIFmKCADDMAAgwATVgAkU8MrdIAAAAASUVORK5CYII=);
+  padding: 2.5rem;
+  height: calc(100vh - 7.5rem);
+  display: -webkit-flex;
+  display: -moz-flex;
+  display: -ms-flex;
+  display: -o-flex;
+  display: flex;
+  justify-content: center;
+  -ms-align-items: center;
+  align-items: center;
 }
+.kirby-focus-field .focus-background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: #efefef url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXR0ZXJuIGlkPSJhIiB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHBhdHRlcm5Vbml0cz0idXNlclNwYWNlT25Vc2UiPjxwYXRoIGZpbGw9InJnYmEoMCwgMCwgMCwgMC4yKSIgZD0iTTAgMGgxMHYxMEgwem0xMCAxMGgxMHYxMEgxMHoiLz48L3BhdHRlcm4+PHJlY3QgZmlsbD0idXJsKCNhKSIgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIvPjwvc3ZnPg==");
+  opacity: 0.45;
+  z-index: 0;
+}
+.focus-preview-container {
+  position: relative;
+  height: 100%;
+  z-index: 1;
+  cursor: crosshair;
+}
+
 
 .kirby-focus-field .focus-preview {
   display: block;
-  width: 100%;
-  height: auto;
+  max-width: 100%;
+  max-height: 100%;
   -webkit-transition: all .25s;
      -moz-transition: all .25s;
           transition: all .25s;

--- a/index.js
+++ b/index.js
@@ -26,6 +26,19 @@ panel.plugin("flokosiol/focus", {
           }
         }
       },
+      watch: {
+      	value(newVal, oldVal) {
+      		var newValArr = newVal.split(',');
+
+      		if(newValArr && newValArr.length) {
+      			var newLeft =  newValArr[0].replace('{"x":', '')
+      			var newTop  = newValArr[1].replace('"y":', '').replace('}', '')
+
+      			if(newLeft != this.left) this.left = newLeft
+	      		if(newTop != this.top)   this.top  = newTop
+      		}
+	    },
+      },
       methods: {
         setFocus(event) {
           this.left = Math.round(event.offsetX / event.target.width * 100) / 100

--- a/index.js
+++ b/index.js
@@ -28,15 +28,9 @@ panel.plugin("flokosiol/focus", {
       },
       watch: {
       	value(newVal, oldVal) {
-      		var newValArr = newVal.split(',');
-
-      		if(newValArr && newValArr.length) {
-      			var newLeft =  newValArr[0].replace('{"x":', '')
-      			var newTop  = newValArr[1].replace('"y":', '').replace('}', '')
-
-      			if(newLeft != this.left) this.left = newLeft
-	      		if(newTop != this.top)   this.top  = newTop
-      		}
+      		var newVal = JSON.parse(newVal);
+      		if(newVal.x != this.left) this.left = newVal.x
+	      	if(newVal.y != this.top)  this.top  = newVal.y
 	    },
       },
       methods: {

--- a/index.js
+++ b/index.js
@@ -36,8 +36,11 @@ panel.plugin("flokosiol/focus", {
       template: `
         <k-field v-bind="$props" v-if="image" class="kirby-focus-field" >
           <div class="focus-box">
-            <img class="focus-preview" :src="image" @click="setFocus" />
-            <div class="focus-point" :style="style"></div>
+            <div class="focus-preview-container">
+            	<img class="focus-preview" :src="image" @click="setFocus" />
+            	<div class="focus-point" :style="style"></div>
+            </div>
+            <div class="focus-background"></div>
           </div>
         </k-field>
       `


### PR DESCRIPTION
Hey 👋

Just started to use the field in a project, thank you for updating it! I've made two changes so PRing them if they can be of use.

https://github.com/flokosiol/kirby-focus/pull/36/commits/40e31fa92d5a7b4183a094139b90973d72300025 makes sure an image is alway fully visible (never overflows the viewport), especially the vertical ones in a full-width field. It's visually opinionated though, here's how it ends up looking:

<img width="1266" alt="capture d ecran 2019-01-25 a 00 15 25" src="https://user-images.githubusercontent.com/14079751/51715159-e17f0980-2037-11e9-8442-127fef6e13f4.png">

https://github.com/flokosiol/kirby-focus/pull/36/commits/bb18236ac3fb4e2c8c8ad676628e4cbac41fb803 watches any `value` change and updates the data if needed. Fixes an issue with the `revert` button not working. 

[edit] My watch function was quite ugly actually, it's getting late... fixed it in https://github.com/flokosiol/kirby-focus/pull/36/commits/4726a0ae36cb68471408e2056e9afdc924e3d6c6