### PR TITLE
Fix compatibility with wide horizontal images

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,7 +3,6 @@
   line-height: 0;
   overflow: hidden;
   padding: 2.5rem;
-  height: calc(100vh - 7.5rem);
   display: -webkit-flex;
   display: -moz-flex;
   display: -ms-flex;
@@ -25,7 +24,6 @@
 }
 .focus-preview-container {
   position: relative;
-  height: 100%;
   z-index: 1;
   cursor: crosshair;
 }
@@ -34,7 +32,7 @@
 .kirby-focus-field .focus-preview {
   display: block;
   max-width: 100%;
-  max-height: 100%;
+  max-height: calc(100vh - 13.5rem);
   -webkit-transition: all .25s;
      -moz-transition: all .25s;
           transition: all .25s;


### PR DESCRIPTION
Apologies, my previous PR had an issue with  wide horizontal images, because the height was set on the container and not on the image itself. 

You can reproduce with a 2/1 image on a tall viewport, and this PR should fix it.