### PR TITLE
Add exception for ImageMagick errors

### DIFF
--- a/src/Focus/ImageMagick.php
+++ b/src/Focus/ImageMagick.php
@@ -2,6 +2,7 @@
 
 namespace Flokosiol\Focus;
 
+use Exception;
 use Kirby\Image\Image;
 use Kirby\Image\Dimensions;
 use Kirby\Image\Darkroom;
@@ -84,7 +85,13 @@ class ImageMagick extends Darkroom
         // remove all null values and join the parts
         $command = implode(' ', array_filter($command));
 
-        exec($command);
+        // try to execute the command
+        exec($command, $output, $return);
+
+        // log broken commands
+        if ($return !== 0) {
+            throw new Exception('The imagemagick convert command could not be executed: ' . $command);
+        }
 
         return $options;
     }

--- a/src/Focus/ImageMagick.php
+++ b/src/Focus/ImageMagick.php
@@ -10,14 +10,6 @@ use Kirby\Toolkit\F;
 
 class ImageMagick extends Darkroom
 {
-    protected function defaults(): array
-    {
-        return parent::defaults() + [
-            'bin'       => 'convert',
-            'interlace' => false,
-        ];
-    }
-
     protected function autoOrient(string $file, array $options)
     {
         if ($options['autoOrient'] === true) {
@@ -42,6 +34,14 @@ class ImageMagick extends Darkroom
     protected function convert(string $file, array $options): string
     {
         return sprintf($options['bin'] . ' "%s"', $file);
+    }
+
+    protected function defaults(): array
+    {
+        return parent::defaults() + [
+            'bin'       => 'convert',
+            'interlace' => false,
+        ];
     }
 
     protected function grayscale(string $file, array $options)


### PR DESCRIPTION
The error reporting is missing in your copy of the ImageMagick class.