### PR TITLE
Make available for Kirby v.3.8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "getkirby/cms": "^3.6",
+        "getkirby/cms": ">=3.6",
         "getkirby/composer-installer": "^1.1"
     }
 }


### PR DESCRIPTION
I would like to introduce a change to the dependency range of Kirby versions to allow the installation in greater versions than the one defined. That puts the responsibility on the user to check for plugin compatibility. At the same time, also allows testing it with beta/rc versions early on.